### PR TITLE
Fix fail msg so that placeholders are properly replaced

### DIFF
--- a/src/os/helpers.sh
+++ b/src/os/helpers.sh
@@ -53,7 +53,8 @@ print_warn() {
 }
 
 print_fail() {
-  print_red "     [✖] $1 $2\n"
+  local message=$(printf "$1" "$2")
+  print_red "     [✖] $message\n"
 }
 
 print_fail_stream() {


### PR DESCRIPTION
Output Before Fix:

[✖] Unsupported version, intended only for Ubuntu %s 14.04

Output After Fix:

[✖] Unsupported version, intended only for Ubuntu 14.04+